### PR TITLE
64 routinecreateqamodify

### DIFF
--- a/app/src/main/java/com/konkuk/moru/core/component/ImageChoiceOptionButtonScreen.kt
+++ b/app/src/main/java/com/konkuk/moru/core/component/ImageChoiceOptionButtonScreen.kt
@@ -36,7 +36,7 @@ fun ImageChoiceOptionButtonScreen(
             .clickable(
                 indication = null,
                 interactionSource = null
-            ){ onCancel() },
+            ) { onCancel() },
         contentAlignment = Alignment.Center
     ) {
         Column(
@@ -51,7 +51,10 @@ fun ImageChoiceOptionButtonScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(110.dp)
-                    .background(color = colors.lightGray.copy(alpha = 0.7f), shape = RoundedCornerShape(12.dp)),
+                    .background(
+                        color = colors.lightGray.copy(alpha = 0.7f),
+                        shape = RoundedCornerShape(12.dp)
+                    ),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
@@ -59,8 +62,11 @@ fun ImageChoiceOptionButtonScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f)
-                        .background(Color.White.copy(alpha = 0.8f), shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp))
-                        .clickable{
+                        .background(
+                            Color.White.copy(alpha = 0.8f),
+                            shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
+                        )
+                        .clickable {
                             onImageSelected()
                         },
                     verticalArrangement = Arrangement.Center,
@@ -77,8 +83,11 @@ fun ImageChoiceOptionButtonScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f)
-                        .background(Color.White.copy(alpha = 0.8f), shape = RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
-                        .clickable{
+                        .background(
+                            Color.White.copy(alpha = 0.8f),
+                            shape = RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
+                        )
+                        .clickable {
                             onCameraSelected()
                         },
                     verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/konkuk/moru/core/component/routinedetail/DraggableAppSearchBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/moru/core/component/routinedetail/DraggableAppSearchBottomSheet.kt
@@ -212,14 +212,14 @@ fun DraggableAppSearchBottomSheetContentPreview() {
     ) {
         DraggableAppSearchBottomSheetContent(
             appList = listOf(
-                UsedAppInRoutine("YouTube", ImageBitmap(64, 64)),
-                UsedAppInRoutine("Instagram", ImageBitmap(64, 64)),
-                UsedAppInRoutine("Twitter", ImageBitmap(64, 64)),
-                UsedAppInRoutine("Facebook", ImageBitmap(64, 64))
+                UsedAppInRoutine("YouTube", ImageBitmap(64, 64), ""),
+                UsedAppInRoutine("Instagram", ImageBitmap(64, 64), ""),
+                UsedAppInRoutine("Twitter", ImageBitmap(64, 64), ""),
+                UsedAppInRoutine("Facebook", ImageBitmap(64, 64), "")
             ),
             selectedAppList = listOf(
-                UsedAppInRoutine("WhatsApp", ImageBitmap(64, 64)),
-                UsedAppInRoutine("Telegram", ImageBitmap(64, 64))
+                UsedAppInRoutine("WhatsApp", ImageBitmap(64, 64), ""),
+                UsedAppInRoutine("Telegram", ImageBitmap(64, 64), "")
             ),
             onAddApp = {},
             onRemoveApp = {}

--- a/app/src/main/java/com/konkuk/moru/core/component/routinedetail/DraggableAppSearchBottomSheet.kt
+++ b/app/src/main/java/com/konkuk/moru/core/component/routinedetail/DraggableAppSearchBottomSheet.kt
@@ -135,7 +135,9 @@ fun DraggableAppSearchBottomSheetContent(
             if (selectedAppList.isNotEmpty()) {
                 Column(
                     modifier = Modifier
-                        .fillMaxWidth().padding(horizontal = 25.dp).padding(bottom = 6.dp),
+                        .fillMaxWidth()
+                        .padding(horizontal = 25.dp)
+                        .padding(bottom = 6.dp),
                     horizontalAlignment = Alignment.End
                 ) {
                     Box(

--- a/app/src/main/java/com/konkuk/moru/core/component/routinedetail/RoutineImageSelectBox.kt
+++ b/app/src/main/java/com/konkuk/moru/core/component/routinedetail/RoutineImageSelectBox.kt
@@ -63,7 +63,7 @@ private fun RoutineImageSelectBoxPreview() {
             .height(140.dp),
         verticalAlignment = Alignment.Top
     ) {
-        RoutineImageSelectBox(){}
+        RoutineImageSelectBox() {}
     }
 
 }

--- a/app/src/main/java/com/konkuk/moru/data/model/UsedAppInRoutine.kt
+++ b/app/src/main/java/com/konkuk/moru/data/model/UsedAppInRoutine.kt
@@ -4,5 +4,6 @@ import androidx.compose.ui.graphics.ImageBitmap
 
 data class UsedAppInRoutine(
     val appName: String,
-    val appIcon: ImageBitmap
+    val appIcon: ImageBitmap,
+    val packageName: String
 )

--- a/app/src/main/java/com/konkuk/moru/data/network/RoutineCreateApi.kt
+++ b/app/src/main/java/com/konkuk/moru/data/network/RoutineCreateApi.kt
@@ -1,0 +1,53 @@
+package com.konkuk.moru.data.network
+
+import okhttp3.MultipartBody
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+// [참고] 실제 엔드포인트 경로는 Swagger 기준으로 맞춰주세요.
+// 아래 경로는 예시입니다. (백엔드와 논의 후 수정)
+// ex) 이미지 업로드: POST /files/upload  → imageKey 반환
+//     루틴 생성: POST /routines
+
+data class ImageUploadResponse(
+    val imageKey: String
+)
+
+data class CreateRoutineRequest(
+    val title: String,
+    val imageKey: String?,
+    val tags: List<String>,
+    val description: String,
+    val steps: List<StepDto>,
+    val selectedApps: List<String>,
+    val isSimple: Boolean,
+    val isUserVisible: Boolean
+)
+
+data class StepDto(
+    val name: String,
+    val stepOrder: Int,
+    val estimatedTime: String
+)
+
+data class CreateRoutineResponse(
+    val id: Long?,      // 서버 스펙에 맞게 조정
+    val message: String?
+)
+
+interface RoutineApi {
+
+    @Multipart
+    @POST("files/upload") // TODO: Swagger 경로로 맞추세요
+    suspend fun uploadImage(
+        @Part image: MultipartBody.Part
+    ): Response<ImageUploadResponse>
+
+    @POST("routines") // TODO: Swagger 경로로 맞추세요
+    suspend fun createRoutine(
+        @Body body: CreateRoutineRequest
+    ): Response<CreateRoutineResponse>
+}

--- a/app/src/main/java/com/konkuk/moru/presentation/routinecreate/component/StepItem.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/routinecreate/component/StepItem.kt
@@ -107,7 +107,7 @@ fun StepItem(
                         .clickable { onDelete(step.id) },
                     tint = colors.mediumGray
                 )
-            }else{
+            } else {
                 Spacer(modifier = Modifier.width(26.dp))
             }
         }

--- a/app/src/main/java/com/konkuk/moru/presentation/routinecreate/component/StepItem.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/routinecreate/component/StepItem.kt
@@ -32,10 +32,11 @@ import com.konkuk.moru.ui.theme.MORUTheme.typography
 @Composable
 fun StepItem(
     step: Step,
+    isFocusingRoutine: Boolean,
     onTitleChange: (String) -> Unit,
     onShowTimePicker: () -> Unit,
     stepCount: Int,
-    onDelete: (stepId: String) -> Unit
+    onDelete: (stepId: String) -> Unit,
 ) {
     var titleInput by remember(step.id) { mutableStateOf(step.title) }
 
@@ -85,14 +86,17 @@ fun StepItem(
             )
 
             // 소요 시간 (기본 텍스트, 클릭 시 다이얼 팝업)
-            Text(
-                text = if (step.time == "") "소요 시간" else step.time,
-                style = typography.body_SB_14,
-                color = colors.charcoalBlack,
-                modifier = Modifier
-                    .weight(0.32f)
-                    .clickable { onShowTimePicker() }
-            )
+            if (isFocusingRoutine) {
+                Text(
+                    text = if (step.time == "") "소요 시간" else step.time,
+                    style = typography.body_SB_14,
+                    color = colors.charcoalBlack,
+                    modifier = Modifier
+                        .weight(0.32f)
+                        .clickable { onShowTimePicker() }
+                )
+            }
+
             if (stepCount > 1) {
                 Spacer(modifier = Modifier.width(10.dp))
                 Icon(
@@ -120,11 +124,23 @@ private fun StepItemPreview() {
             Step(title = "활동명", time = "")
         )
     } // 초기 step 1개
-    StepItem(
-        step = stepList[0],
-        onTitleChange = { stepList[0] = stepList[0].copy(title = it) },
-        onShowTimePicker = { },
-        stepCount = 2,
-        onDelete = { stepList.removeAt(0) }
-    )
+    Column {
+        StepItem(
+            step = stepList[0],
+            isFocusingRoutine = false,
+            onTitleChange = { stepList[0] = stepList[0].copy(title = it) },
+            onShowTimePicker = { },
+            stepCount = 2,
+            onDelete = { stepList.removeAt(0) },
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        StepItem(
+            step = stepList[0],
+            isFocusingRoutine = true,
+            onTitleChange = { stepList[0] = stepList[0].copy(title = it) },
+            onShowTimePicker = { },
+            stepCount = 2,
+            onDelete = { stepList.removeAt(0) },
+        )
+    }
 }

--- a/app/src/main/java/com/konkuk/moru/presentation/routinecreate/screen/RoutineCreateScreen.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/routinecreate/screen/RoutineCreateScreen.kt
@@ -406,6 +406,7 @@ fun RoutineCreateScreen(
         },
     )
 }
+
 private fun createImageUri(context: Context): Uri {
     val imageFile = File.createTempFile(
         "moru_camera_", ".jpg",

--- a/app/src/main/java/com/konkuk/moru/presentation/routinecreate/screen/RoutineCreateScreen.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/routinecreate/screen/RoutineCreateScreen.kt
@@ -1,6 +1,9 @@
 package com.konkuk.moru.presentation.routinecreate.screen
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -45,6 +48,8 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.konkuk.moru.R
@@ -64,6 +69,7 @@ import com.konkuk.moru.presentation.routinecreate.viewmodel.RoutineCreateViewMod
 import com.konkuk.moru.ui.theme.MORUTheme.colors
 import com.konkuk.moru.ui.theme.MORUTheme.typography
 import kotlinx.coroutines.launch
+import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("DefaultLocale")
@@ -81,6 +87,29 @@ fun RoutineCreateScreen(
 
     var isImageOptionVisible by remember { mutableStateOf(false) }
     var isTimePickerVisible by remember { mutableStateOf(false) }
+
+    val context = LocalContext.current
+    val cameraImageUriState = remember { mutableStateOf<Uri?>(null) }
+
+    val takePictureLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success) {
+            viewModel.imageUri.value = cameraImageUriState.value
+        }
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            val uri = createImageUri(context)
+            cameraImageUriState.value = uri
+            takePictureLauncher.launch(uri)
+        } else {
+            // 권한 거부 시: 따로 안내 필요하면 스낵바/토스트 등 처리
+        }
+    }
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
@@ -112,8 +141,6 @@ fun RoutineCreateScreen(
 //        UsedAppInRoutine("Instagram", dummyBitmap),
 //        UsedAppInRoutine("Twitter", dummyBitmap)
 //    )
-
-    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.loadInstalledApps(context)
@@ -172,7 +199,7 @@ fun RoutineCreateScreen(
                         verticalAlignment = Alignment.Top
                     ) {
                         RoutineImageSelectBox(
-                            selectedImageUri = imageUriState.value,
+                            selectedImageUri = viewModel.imageUri.value,
                             onClick = {
                                 isImageOptionVisible = true
                                 focusManager.clearFocus()
@@ -244,6 +271,7 @@ fun RoutineCreateScreen(
                     StepItem(
                         step = step,
                         stepCount = stepList.size,
+                        isFocusingRoutine = isFocusingRoutine,
                         onTitleChange = { newTitle ->
                             viewModel.updateStepTitle(step.id, newTitle)
                         },
@@ -310,7 +338,9 @@ fun RoutineCreateScreen(
                         indication = null,
                         interactionSource = null
                     ) {
-                        viewModel.submitRoutine()
+                        // TODO: 이미지 업로드하여 imageKey 획득 필요
+                        val imageKey: String? = null // [임시] 서버 업로드 연동 후 실제 키로 치환
+                        viewModel.submitRoutine(imageKey) // [변경] DTO 생성/로그
                         navController.popBackStack()
                     },
                 contentAlignment = Alignment.Center
@@ -331,7 +361,20 @@ fun RoutineCreateScreen(
                     isImageOptionVisible = false
                 },
                 onCameraSelected = {
-                    // TODO: 카메라 구현 필요 (추가 설명 원할 시 말해줘)
+                    // [변경] 실제 카메라 촬영 동작
+                    val permission = Manifest.permission.CAMERA
+                    val isGranted = ContextCompat.checkSelfPermission(
+                        context, permission
+                    ) == PackageManager.PERMISSION_GRANTED
+
+                    if (isGranted) {
+                        val uri = createImageUri(context)
+                        cameraImageUriState.value = uri
+                        takePictureLauncher.launch(uri)
+                    } else {
+                        cameraPermissionLauncher.launch(permission)
+                    }
+                    isImageOptionVisible = false
                 },
                 onCancel = { isImageOptionVisible = false }
             )
@@ -361,6 +404,17 @@ fun RoutineCreateScreen(
         onRemoveApp = { app ->
             viewModel.removeAppFromSelected(app)
         },
+    )
+}
+private fun createImageUri(context: Context): Uri {
+    val imageFile = File.createTempFile(
+        "moru_camera_", ".jpg",
+        context.cacheDir // 외부 저장 권한 없이 캐시에 저장
+    )
+    return FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.fileprovider",
+        imageFile
     )
 }
 

--- a/app/src/main/java/com/konkuk/moru/presentation/routinecreate/viewmodel/RoutineCreateVIewModel.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/routinecreate/viewmodel/RoutineCreateVIewModel.kt
@@ -150,7 +150,8 @@ class RoutineCreateViewModel : ViewModel() {
                         )
                     )
                 }
-            } catch (_: Exception) {}
+            } catch (_: Exception) {
+            }
         }
     }
 
@@ -168,6 +169,7 @@ class RoutineCreateViewModel : ViewModel() {
                 drawable.draw(canvas)
                 bmp
             }
+
             else -> {
                 val bmp = createBitmap(
                     drawable.intrinsicWidth.coerceAtLeast(1),

--- a/app/src/main/java/com/konkuk/moru/presentation/routinecreate/viewmodel/RoutineCreateVIewModel.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/routinecreate/viewmodel/RoutineCreateVIewModel.kt
@@ -3,7 +3,11 @@ package com.konkuk.moru.presentation.routinecreate.viewmodel
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.util.Log
 import androidx.compose.runtime.mutableStateListOf
@@ -12,6 +16,25 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.lifecycle.ViewModel
 import com.konkuk.moru.data.model.Step
 import com.konkuk.moru.data.model.UsedAppInRoutine
+import androidx.core.graphics.createBitmap
+
+// [유지] 서버 DTO들
+data class CreateRoutineRequest(
+    val title: String,
+    val imageKey: String?,
+    val tags: List<String>,
+    val description: String,
+    val steps: List<StepDto>,
+    val selectedApps: List<String>,
+    val isSimple: Boolean,
+    val isUserVisible: Boolean
+)
+
+data class StepDto(
+    val name: String,
+    val stepOrder: Int,
+    val estimatedTime: String // ISO-8601 duration
+)
 
 class RoutineCreateViewModel : ViewModel() {
 
@@ -21,7 +44,7 @@ class RoutineCreateViewModel : ViewModel() {
     val routineTitle = mutableStateOf("")
     val routineDescription = mutableStateOf("")
     val tagList = mutableStateListOf<String>()
-    val stepList = mutableStateListOf(Step(title = "", time = "")) // ✅ 초기에도 id 생성
+    val stepList = mutableStateListOf(Step(title = "", time = ""))
     val editingStepId = mutableStateOf<String?>(null)
     val appList = mutableStateListOf<UsedAppInRoutine>()
     val selectedAppList = mutableStateListOf<UsedAppInRoutine>()
@@ -43,10 +66,7 @@ class RoutineCreateViewModel : ViewModel() {
     }
 
     fun addTag(tag: String) {
-//        if (tag.isNotBlank() && !tagList.contains(tag)) {
-//            tagList.add(tag)
-//        }
-        tagList.add(tag) //Todo: 중복 체크 로직 추가 필요
+        tagList.add(tag) // TODO: 중복 체크 로직 추가 필요
     }
 
     fun removeTag(tag: String) {
@@ -80,6 +100,20 @@ class RoutineCreateViewModel : ViewModel() {
         return stepList.find { it.id == id }?.time
     }
 
+    // [유지] HH:MM:SS → PT#H#M#S 변환
+    private fun String.toIsoDuration(): String {
+        val parts = split(":")
+        val h = parts.getOrNull(0)?.toIntOrNull() ?: 0
+        val m = parts.getOrNull(1)?.toIntOrNull() ?: 0
+        val s = parts.getOrNull(2)?.toIntOrNull() ?: 0
+        return buildString {
+            append("PT")
+            if (h > 0) append("${h}H")
+            if (m > 0) append("${m}M")
+            if (s > 0 || (h == 0 && m == 0)) append("${s}S")
+        }
+    }
+
     @SuppressLint("DefaultLocale")
     fun confirmTime(hour: Int, minute: Int, second: Int) {
         val formatted = String.format("%02d:%02d:%02d", hour, minute, second)
@@ -95,53 +129,93 @@ class RoutineCreateViewModel : ViewModel() {
         val pm = context.packageManager
         val apps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
 
-        appList.clear() // 중복 방지
+        appList.clear()
 
         apps.forEach { appInfo ->
             try {
                 val label = pm.getApplicationLabel(appInfo).toString()
-                val iconDrawable = pm.getApplicationIcon(appInfo)
+                val drawable = pm.getApplicationIcon(appInfo)
 
-                val bitmap = (iconDrawable as BitmapDrawable).bitmap
+                // [유지] 어떤 Drawable이 와도 안전하게 비트맵 변환
+                val bitmap = drawableToBitmap(drawable)
                 val imageBitmap = bitmap.asImageBitmap()
+                val pkg = appInfo.packageName
 
-                // 이미 추가된 앱은 건너뜀
-                if (appList.none { it.appName == label }) {
-                    appList.add(UsedAppInRoutine(appName = label, appIcon = imageBitmap))
+                if (appList.none { it.packageName == pkg }) {
+                    appList.add(
+                        UsedAppInRoutine(
+                            appName = label,
+                            appIcon = imageBitmap,
+                            packageName = pkg
+                        )
+                    )
                 }
             } catch (_: Exception) {}
         }
     }
 
+    // [유지] Drawable → Bitmap 안전 변환
+    private fun drawableToBitmap(drawable: Drawable): Bitmap {
+        return when (drawable) {
+            is BitmapDrawable -> drawable.bitmap
+            is AdaptiveIconDrawable -> {
+                val bmp = createBitmap(
+                    drawable.intrinsicWidth.coerceAtLeast(1),
+                    drawable.intrinsicHeight.coerceAtLeast(1)
+                )
+                val canvas = Canvas(bmp) // [중요] android.graphics.Canvas 사용
+                drawable.setBounds(0, 0, canvas.width, canvas.height)
+                drawable.draw(canvas)
+                bmp
+            }
+            else -> {
+                val bmp = createBitmap(
+                    drawable.intrinsicWidth.coerceAtLeast(1),
+                    drawable.intrinsicHeight.coerceAtLeast(1)
+                )
+                val canvas = Canvas(bmp) // [중요] android.graphics.Canvas 사용
+                drawable.setBounds(0, 0, canvas.width, canvas.height)
+                drawable.draw(canvas)
+                bmp
+            }
+        }
+    }
+
     fun addAppToSelected(app: UsedAppInRoutine) {
-        if (app !in selectedAppList && selectedAppList.size < 4) {
+        if (selectedAppList.none { it.packageName == app.packageName } && selectedAppList.size < 4) {
             selectedAppList.add(app)
         }
     }
+
     fun removeAppFromSelected(app: UsedAppInRoutine) {
-        selectedAppList.remove(app)
+        selectedAppList.removeAll { it.packageName == app.packageName } // [변경] 패키지 기준
     }
 
-    fun submitRoutine() {
-        val routineData = mapOf(
-            "title" to routineTitle.value,
-            "description" to routineDescription.value,
-            "isFocused" to isFocusingRoutine.value,
-            "showUser" to showUser.value,
-            "tagList" to tagList.toList(),
-            "steps" to stepList.map { it.copy() },
-            "apps" to appList.map { it.copy() },
-            "imageUri" to imageUri.value?.toString()
+    // [유지] 서버 전송용 DTO 생성기
+    fun buildCreateRoutineRequest(imageKey: String?): CreateRoutineRequest {
+        val stepsDto = stepList.mapIndexed { idx, step ->
+            StepDto(
+                name = step.title,
+                stepOrder = idx + 1,
+                estimatedTime = (step.time.takeIf { it.isNotBlank() } ?: "00:00:00").toIsoDuration()
+            )
+        }
+        return CreateRoutineRequest(
+            title = routineTitle.value,
+            imageKey = imageKey,
+            tags = tagList.toList(),
+            description = routineDescription.value,
+            steps = stepsDto,
+            selectedApps = selectedAppList.map { it.packageName }, // [중요 변경]
+            isSimple = !isFocusingRoutine.value, // [중요 매핑]
+            isUserVisible = showUser.value
         )
+    }
 
-        // ✅ Log 출력 추가
-        Log.d("RoutineCreate", "루틴 제목: ${routineTitle.value}")
-        Log.d("RoutineCreate", "설명: ${routineDescription.value}")
-        Log.d("RoutineCreate", "집중 루틴 여부: ${isFocusingRoutine.value}")
-        Log.d("RoutineCreate", "사용자 공개 여부: ${showUser.value}")
-        Log.d("RoutineCreate", "태그: ${tagList.toList()}")
-        Log.d("RoutineCreate", "스텝: ${stepList.map { "${it.title} - ${it.time}" }}")
-        Log.d("RoutineCreate", "사용 앱: ${appList.map { "${it.appName} - ${it.appIcon}" }}")
-        Log.d("RoutineCreate", "이미지 URI: ${imageUri.value?.toString()}")
+    fun submitRoutine(imageKey: String?) {
+        val req = buildCreateRoutineRequest(imageKey)
+        Log.d("RoutineCreate", "CreateRoutineRequest → $req")
+        Log.d("RoutineCreate", "이미지 URI(Local): ${imageUri.value?.toString()}")
+        // TODO: Repository.createRoutine(req) 호출로 네트워크 연결
     }
 }

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -11,6 +11,11 @@
         name="images_cache"
         path="." />
 
+    <!-- file: app/src/main/res/xml/file_paths.xml -->
+    <!-- [신규 파일] FileProvider 경로 매핑 -->
+    <!-- 앱 캐시 경로 전체 허용 (임시 촬영 파일 저장) -->
+    <cache-path name="camera_cache" path="." />
+
 </paths>
 
 


### PR DESCRIPTION
## 🖼️ 스크린샷
This pull request introduces several improvements and new features to the routine creation flow, focusing on camera image selection, API integration, and data modeling for routines and apps. The most important changes are grouped below:

**Camera Integration & Image Selection:**
* Implemented camera permission handling and image capture using the device camera. Images are stored in the app's cache and exposed via a `FileProvider`. The camera workflow now requests permissions if needed and launches the camera, updating the selected image URI on success. (`RoutineCreateScreen.kt`, [[1]](diffhunk://#diff-71f5f16f0e7364d77513e7780bd4b61df55054a0986239ad1bfb028786bd31e1R91-R113) [[2]](diffhunk://#diff-71f5f16f0e7364d77513e7780bd4b61df55054a0986239ad1bfb028786bd31e1L334-R377) [[3]](diffhunk://#diff-71f5f16f0e7364d77513e7780bd4b61df55054a0986239ad1bfb028786bd31e1R410-R421)
* The image selection UI now supports both gallery and camera sources, and the selected image URI is managed via the ViewModel. (`RoutineCreateScreen.kt`, [app/src/main/java/com/konkuk/moru/presentation/routinecreate/screen/RoutineCreateScreen.ktL175-R202](diffhunk://#diff-71f5f16f0e7364d77513e7780bd4b61df55054a0986239ad1bfb028786bd31e1L175-R202))

**Routine Creation API Integration:**
* Added `RoutineCreateApi.kt` with definitions for image upload and routine creation endpoints, including DTOs for requests and responses. This sets up the structure for backend integration. (`RoutineCreateApi.kt`, [app/src/main/java/com/konkuk/moru/data/network/RoutineCreateApi.ktR1-R53](diffhunk://#diff-a90cc0787af14142f3e2140ca9dfe9affdfb12eeb0906680bce877de3cdaa6feR1-R53))
* Updated the ViewModel to use DTOs for routine creation, including ISO-8601 duration formatting for step times. (`RoutineCreateVIewModel.kt`, [[1]](diffhunk://#diff-153467ad21a30b193a75473c72a6b8eec6134da3f55a2daffeea3868dd89ae4bR19-R37) [[2]](diffhunk://#diff-153467ad21a30b193a75473c72a6b8eec6134da3f55a2daffeea3868dd89ae4bR103-R116)
* The routine submission flow now accepts an `imageKey` for backend compatibility. (`RoutineCreateScreen.kt`, [app/src/main/java/com/konkuk/moru/presentation/routinecreate/screen/RoutineCreateScreen.ktL313-R343](diffhunk://#diff-71f5f16f0e7364d77513e7780bd4b61df55054a0986239ad1bfb028786bd31e1L313-R343))

**Data Modeling Improvements:**
* Extended the `UsedAppInRoutine` data class to include a `packageName` field, enabling more precise app identification. (`UsedAppInRoutine.kt`, [app/src/main/java/com/konkuk/moru/data/model/UsedAppInRoutine.ktL7-R8](diffhunk://#diff-75de58fb2df4313e810c67a0ab1b7e5e4a843b84ab5069890b5432544ccc02c8L7-R8))
* Updated usages of `UsedAppInRoutine` throughout the codebase to include the new `packageName` parameter. (`DraggableAppSearchBottomSheet.kt`, [app/src/main/java/com/konkuk/moru/core/component/routinedetail/DraggableAppSearchBottomSheet.ktL215-R224](diffhunk://#diff-aa8a6bc83ea37fd3edef25f125c29cd717f72b836bf0ad0ad037373a0caf4a3bL215-R224))

**UI & Composables Updates:**
* Improved the `StepItem` composable to conditionally show the time picker based on a new `isFocusingRoutine` flag, and updated previews to demonstrate both states. (`StepItem.kt`, [[1]](diffhunk://#diff-da91c5fdfff259bf863a7a545c3d71c8ff414e3821569aba3c16af767f9834cbR35-R39) [[2]](diffhunk://#diff-da91c5fdfff259bf863a7a545c3d71c8ff414e3821569aba3c16af767f9834cbR89) [[3]](diffhunk://#diff-da91c5fdfff259bf863a7a545c3d71c8ff414e3821569aba3c16af767f9834cbR98-R99) [[4]](diffhunk://#diff-da91c5fdfff259bf863a7a545c3d71c8ff414e3821569aba3c16af767f9834cbR127-R145)
* Refactored background and modifier usage in image choice and app search UI components for better readability and maintainability. (`ImageChoiceOptionButtonScreen.kt`, [[1]](diffhunk://#diff-27b58b6b9248cdebc5f0924a0350fba577e1c38d2685c13eb4d80f72cd8d0a53L54-R68) [[2]](diffhunk://#diff-27b58b6b9248cdebc5f0924a0350fba577e1c38d2685c13eb4d80f72cd8d0a53L80-R89); `DraggableAppSearchBottomSheet.kt`, [[3]](diffhunk://#diff-aa8a6bc83ea37fd3edef25f125c29cd717f72b836bf0ad0ad037373a0caf4a3bL138-R140)

**General Refactoring & Cleanup:**
* Removed commented code and clarified TODOs for future improvements, such as duplicate tag checking and endpoint path updates. (`RoutineCreateVIewModel.kt`, [app/src/main/java/com/konkuk/moru/presentation/routinecreate/viewmodel/RoutineCreateVIewModel.ktL46-R69](diffhunk://#diff-153467ad21a30b193a75473c72a6b8eec6134da3f55a2daffeea3868dd89ae4bL46-R69))

Let me know if you'd like a walkthrough of any specific part of these changes!

## ✅ 체크리스트
- [ ] 작업 1
- [ ] 작업 2

## 👀 리뷰 요청사항 (리뷰어가 집중해서 봐야할 부분)