### PR TITLE
feat: implement user profile update and nickname availability check f…

### DIFF
--- a/app/src/main/java/com/konkuk/moru/core/component/button/MoruButtonTypeA.kt
+++ b/app/src/main/java/com/konkuk/moru/core/component/button/MoruButtonTypeA.kt
@@ -31,8 +31,9 @@ fun MoruButtonTypeA(
             .background(backgroundColor, shape = RoundedCornerShape(10.dp))
             .clickable(
                 indication = null,
-                interactionSource = null
-            ) { onClick() }, // Todo 임시로 항상 작동하도록 설정함
+                interactionSource = null,
+                enabled = enabled
+            ) { onClick() },
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/app/src/main/java/com/konkuk/moru/data/dto/request/FavoriteTagRequest.kt
+++ b/app/src/main/java/com/konkuk/moru/data/dto/request/FavoriteTagRequest.kt
@@ -1,0 +1,12 @@
+package com.konkuk.moru.data.dto.request
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FavoriteTagRequest(
+    @SerialName("tagIds")
+    @SerializedName("tagIds")
+    val tagIds: List<String>
+)

--- a/app/src/main/java/com/konkuk/moru/data/dto/request/UpdateUserProfileRequest.kt
+++ b/app/src/main/java/com/konkuk/moru/data/dto/request/UpdateUserProfileRequest.kt
@@ -1,0 +1,12 @@
+package com.konkuk.moru.data.dto.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateUserProfileRequest(
+    val nickname: String,
+    val gender: String,
+    val birthday: String,
+    val bio: String,
+    val profileImageUrl: String?
+)

--- a/app/src/main/java/com/konkuk/moru/data/dto/response/NicknameCheckResponse.kt
+++ b/app/src/main/java/com/konkuk/moru/data/dto/response/NicknameCheckResponse.kt
@@ -1,0 +1,6 @@
+package com.konkuk.moru.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NicknameCheckResponse(val available: Boolean)

--- a/app/src/main/java/com/konkuk/moru/data/dto/response/UpdateUserProfileResponse.kt
+++ b/app/src/main/java/com/konkuk/moru/data/dto/response/UpdateUserProfileResponse.kt
@@ -1,0 +1,16 @@
+package com.konkuk.moru.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateUserProfileResponse(
+    val id: String,
+    val nickname: String,
+    val gender: String,
+    val birthday: String,
+    val bio: String,
+    val profileImageUrl: String?,
+    val routineCount: Int = 0,
+    val followerCount: Int = 0,
+    val followingCount: Int = 0
+)

--- a/app/src/main/java/com/konkuk/moru/data/repositoryimpl/OBUserRepositoryImpl.kt
+++ b/app/src/main/java/com/konkuk/moru/data/repositoryimpl/OBUserRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package com.konkuk.moru.data.repositoryimpl
+
+import android.util.Log
+import com.konkuk.moru.data.dto.request.FavoriteTagRequest
+import com.konkuk.moru.data.dto.request.UpdateUserProfileRequest
+import com.konkuk.moru.data.dto.response.UpdateUserProfileResponse
+import com.konkuk.moru.data.service.OBUserService
+import com.konkuk.moru.domain.repository.OBUserRepository
+import retrofit2.HttpException
+import javax.inject.Inject
+import javax.inject.Named
+
+
+class OBUserRepositoryImpl @Inject constructor(
+    @Named("obUserAuthed") private val authedService: OBUserService,
+    @Named("obUserAuthless") private val authlessService: OBUserService
+) : OBUserRepository {
+
+    override suspend fun checkNicknameAvailable(nickname: String): Result<Boolean> = runCatching {
+        Log.d("onboarding", "checkNicknameAvailable() request nickname=$nickname (AUTHeD ONLY)")
+
+        val res = authedService.checkNickname(nickname)
+        Log.d("onboarding", "checkNicknameAvailable() authed resp code=${res.code()} body=${res.body()}")
+
+        if (!res.isSuccessful) throw HttpException(res)
+        res.body()?.available == true
+    }.onFailure { e ->
+        Log.d("onboarding", "checkNicknameAvailable() failed: ${e.message}")
+    }
+
+    override suspend fun updateProfile(body: UpdateUserProfileRequest): Result<UpdateUserProfileResponse> =
+        runCatching {
+            Log.d("onboarding", "updateProfile() request body=$body")
+            val res = authedService.updateMe(body)
+            Log.d("onboarding", "updateProfile() response code=${res.code()} body=${res.body()}")
+            if (!res.isSuccessful) throw HttpException(res)
+            res.body()!!
+        }.onFailure { e ->
+            Log.d("onboarding", "updateProfile() failed: ${e.message}")
+        }
+
+    override suspend fun addFavoriteTags(body: FavoriteTagRequest): Result<Unit> =
+        runCatching {
+            Log.d("onboarding", "addFavoriteTags() request body=$body")
+            val res = authedService.addFavoriteTags(body)
+            val code = res.code()
+            val err = res.errorBody()?.string()
+            Log.d("onboarding", "addFavoriteTags() response code=$code${if (err != null) " error=$err" else ""}")
+            if (!res.isSuccessful) throw HttpException(res)
+            Unit
+        }.onFailure { e ->
+            Log.d("onboarding", "addFavoriteTags() failed: ${e.message}")
+        }
+}

--- a/app/src/main/java/com/konkuk/moru/data/service/OBUserService.kt
+++ b/app/src/main/java/com/konkuk/moru/data/service/OBUserService.kt
@@ -1,0 +1,30 @@
+package com.konkuk.moru.data.service
+
+import com.konkuk.moru.data.dto.request.FavoriteTagRequest
+import com.konkuk.moru.data.dto.request.UpdateUserProfileRequest
+import com.konkuk.moru.data.dto.response.NicknameCheckResponse
+import com.konkuk.moru.data.dto.response.UpdateUserProfileResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface OBUserService {
+    @GET("/api/user/nickname/{nickname}")
+    suspend fun checkNickname(
+//        @Path("nickname") nickname: String
+        @Path(value = "nickname", encoded = true) nickname: String
+    ): Response<NicknameCheckResponse>
+
+    @PATCH("/api/user/me")
+    suspend fun updateMe(
+        @Body body: UpdateUserProfileRequest
+    ): Response<UpdateUserProfileResponse>
+
+    @POST("/api/user/favorite-tag")
+    suspend fun addFavoriteTags(
+        @Body body: FavoriteTagRequest
+    ): Response<Unit>
+}

--- a/app/src/main/java/com/konkuk/moru/di/NetworkModule.kt
+++ b/app/src/main/java/com/konkuk/moru/di/NetworkModule.kt
@@ -10,6 +10,7 @@ import com.konkuk.moru.data.service.AuthService
 import com.konkuk.moru.data.service.InsightService
 import com.konkuk.moru.data.service.RoutineService
 import com.konkuk.moru.data.service.NotificationService
+import com.konkuk.moru.data.service.OBUserService
 import com.konkuk.moru.data.service.RoutineFeedService
 import com.konkuk.moru.data.service.RoutineUserService
 import com.konkuk.moru.data.service.SearchService
@@ -27,12 +28,22 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
 import javax.inject.Named
+import kotlin.jvm.java
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
+    @Provides @Singleton
+    @Named("obUserAuthed")
+    fun provideOBUserServiceAuthed(@Named("jsonRetrofit") retrofit: Retrofit): OBUserService =
+        retrofit.create(OBUserService::class.java)
 
+    // [추가] 무인증용 OBUserService (닉네임 체크 전용)
+    @Provides @Singleton
+    @Named("obUserAuthless")
+    fun provideOBUserServiceAuthless(@Named("authlessRetrofit") retrofit: Retrofit): OBUserService =
+        retrofit.create(OBUserService::class.java)
 
     @Provides @Singleton
     fun provideGson(): Gson = GsonBuilder()
@@ -115,6 +126,19 @@ object NetworkModule {
             .client(okHttp)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
+
+    @Provides
+    @Singleton
+    @Named("jsonRetrofit")
+    fun provideJsonRetrofit(
+        baseUrl: String,
+        okHttp: OkHttpClient,
+        json: Json
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl)
+        .client(okHttp)
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .build()
 
     @Provides @Singleton
     fun provideAuthService(retrofit: Retrofit): AuthService =

--- a/app/src/main/java/com/konkuk/moru/di/RepositoryModule.kt
+++ b/app/src/main/java/com/konkuk/moru/di/RepositoryModule.kt
@@ -3,6 +3,7 @@ package com.konkuk.moru.di
 import com.konkuk.moru.data.repositoryimpl.AuthRepositoryImpl
 import com.konkuk.moru.data.repositoryimpl.InsightRepositoryImpl
 import com.konkuk.moru.data.repositoryimpl.NotificationRepositoryImpl
+import com.konkuk.moru.data.repositoryimpl.OBUserRepositoryImpl
 import com.konkuk.moru.data.repositoryimpl.RoutineFeedRepositoryImpl
 import com.konkuk.moru.data.repositoryimpl.RoutineUserRepositoryImpl
 import com.konkuk.moru.data.repositoryimpl.SearchRepositoryImpl
@@ -10,10 +11,12 @@ import com.konkuk.moru.data.repositoryimpl.SocialRepositoryImpl
 import com.konkuk.moru.domain.repository.AuthRepository
 import com.konkuk.moru.domain.repository.InsightRepository
 import com.konkuk.moru.domain.repository.NotificationRepository
+import com.konkuk.moru.domain.repository.OBUserRepository
 import com.konkuk.moru.domain.repository.RoutineFeedRepository
 import com.konkuk.moru.domain.repository.RoutineUserRepository
 import com.konkuk.moru.domain.repository.SearchRepository
 import com.konkuk.moru.domain.repository.SocialRepository
+import com.konkuk.moru.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -23,6 +26,9 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+
+    @Binds @Singleton
+    abstract fun bindOBUserRepository(impl: OBUserRepositoryImpl): OBUserRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/konkuk/moru/domain/repository/OBUserRepository.kt
+++ b/app/src/main/java/com/konkuk/moru/domain/repository/OBUserRepository.kt
@@ -1,0 +1,11 @@
+package com.konkuk.moru.domain.repository
+
+import com.konkuk.moru.data.dto.request.FavoriteTagRequest
+import com.konkuk.moru.data.dto.request.UpdateUserProfileRequest
+import com.konkuk.moru.data.dto.response.UpdateUserProfileResponse
+
+interface OBUserRepository {
+    suspend fun checkNicknameAvailable(nickname: String): Result<Boolean>
+    suspend fun updateProfile(body: UpdateUserProfileRequest): Result<UpdateUserProfileResponse>
+    suspend fun addFavoriteTags(body: FavoriteTagRequest): Result<Unit>
+}

--- a/app/src/main/java/com/konkuk/moru/presentation/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/onboarding/OnboardingScreen.kt
@@ -18,7 +18,7 @@ import com.konkuk.moru.presentation.onboarding.component.OnboardingPage
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun OnboardingScreen(
-    viewModel: OnboardingViewModel = hiltViewModel(), //TODO: 추후 주석 해제 예정
+    viewModel: OnboardingViewModel = hiltViewModel(),
     onFinish: () -> Unit
 ) {
     val pagerState = rememberPagerState()

--- a/app/src/main/java/com/konkuk/moru/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/onboarding/OnboardingViewModel.kt
@@ -5,6 +5,9 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.konkuk.moru.core.datastore.OnboardingPreference
+import com.konkuk.moru.data.dto.request.FavoriteTagRequest
+import com.konkuk.moru.data.dto.request.UpdateUserProfileRequest
+import com.konkuk.moru.domain.repository.OBUserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,15 +19,80 @@ data class UserInfo(
     val nickname: String = "",
     val gender: String = "",
     val birthday: String = "",
-    val introduction: String = "",
+    val bio: String = "",
     val tags: List<String> = emptyList(),
     val profileImageUri: String? = null
 )
 
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val userRepository: OBUserRepository
 ) : ViewModel() {
+
+    // ✅ 닉네임 중복 확인 상태
+    private val _nicknameAvailable = MutableStateFlow<Boolean?>(null)
+    val nicknameAvailable: StateFlow<Boolean?> = _nicknameAvailable
+
+
+    fun checkNicknameAvailability(nickname: String) {
+        Log.d("onboarding", "checkNicknameAvailability() request: nickname=$nickname")
+        viewModelScope.launch {
+            val result = userRepository.checkNicknameAvailable(nickname)
+            result.onSuccess { ok ->
+                Log.d("onboarding", "checkNicknameAvailability() success: available=$ok")
+                _nicknameAvailable.value = ok
+                if (ok) updateNickname(nickname)
+            }.onFailure { e ->
+                Log.d("onboarding", "checkNicknameAvailability() failed: ${e.message}")
+                _nicknameAvailable.value = false
+            }
+        }
+    }
+
+    // ✅ 유저 정보 제출 함수
+    fun submitUserInfo() {
+        viewModelScope.launch {
+            val info = _userInfo.value
+
+            val serverGender = when (info.gender.trim()) {
+                "남자" -> "MALE"
+                "여자" -> "FEMALE"
+                else -> "MALE" // 기본값 설정: 서버에서 요구하는 값이 없을 경우
+            }
+
+            val imageForServer = info.profileImageUri?.let { uri ->
+                if (uri.startsWith("http://") || uri.startsWith("https://")) uri else "null"
+            }
+
+            val safeBirthday = info.birthday.trim()
+
+            Log.d("onboarding", "updateProfile() FINAL body (sanitized)=" +
+                    " nickname=${info.nickname.trim()}," +
+                    " gender=$serverGender," +
+                    " birthday=$safeBirthday," +
+                    " bio=${info.bio.trim()}," +
+                    " profileImageUrl=$imageForServer"
+            )
+
+            userRepository.updateProfile(
+                UpdateUserProfileRequest(
+                    nickname = info.nickname.trim(),
+                    gender = serverGender,
+                    birthday = safeBirthday,
+                    bio = info.bio.trim(),
+                    profileImageUrl = info.profileImageUri
+                )
+            )
+        }
+    }
+
+    // ✅ 즐겨찾는 태그 제출 함수
+    fun submitFavoriteTags(tagIds: List<String>) {
+        viewModelScope.launch {
+            userRepository.addFavoriteTags(FavoriteTagRequest(tagIds))
+        }
+    }
 
     companion object {
         const val LAST_PAGE_INDEX = 6
@@ -43,10 +111,12 @@ class OnboardingViewModel @Inject constructor(
     // ✅ 유저 정보 업데이트 함수들
     fun updateNickname(nickname: String) {
         _userInfo.value = _userInfo.value.copy(nickname = nickname)
+        Log.d("onboarding", "Nickname updated: $nickname")
     }
 
     fun updateGender(gender: String) {
         _userInfo.value = _userInfo.value.copy(gender = gender)
+        Log.d("onboarding", "Gender updated: $gender")
     }
 
     fun updateBirthday(birthday: String) {
@@ -54,7 +124,7 @@ class OnboardingViewModel @Inject constructor(
     }
 
     fun updateIntroduction(intro: String) {
-        _userInfo.value = _userInfo.value.copy(introduction = intro)
+        _userInfo.value = _userInfo.value.copy(bio = intro)
     }
 
     fun updateTags(tags: List<String>) {
@@ -62,7 +132,7 @@ class OnboardingViewModel @Inject constructor(
     }
 
     fun updateProfileImage(uri: String?) {
-        _userInfo.value = _userInfo.value.copy(profileImageUri = uri) // [추가]
+        _userInfo.value = _userInfo.value.copy(profileImageUri = uri)
     }
 
     // ✅ 다음 페이지 로직
@@ -83,7 +153,7 @@ class OnboardingViewModel @Inject constructor(
             // ✅ 추후 서버로 _userInfo.value 를 전송하는 API 호출 예정
             OnboardingPreference.setOnboardingComplete(context)
             _isOnboardingComplete.value = true
-            Log.d("Onboarding", "✅ 온보딩 완료됨")
+            Log.d("onboarding", "✅ 온보딩 완료됨")
         }
     }
 }

--- a/app/src/main/java/com/konkuk/moru/presentation/onboarding/component/NickNameTextField.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/onboarding/component/NickNameTextField.kt
@@ -2,6 +2,7 @@ package com.konkuk.moru.presentation.onboarding.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -33,6 +34,7 @@ import com.konkuk.moru.ui.theme.MORUTheme.typography
 fun NickNameTextField(
     value: String,
     onValueChange: (String) -> Unit,
+    onCheckValidNickname: () -> Unit,
     isValid: Boolean,
     placeholder: String,
     keyboardType: KeyboardType = KeyboardType.Text,
@@ -50,7 +52,11 @@ fun NickNameTextField(
 
     BasicTextField(
         value = value,
-        onValueChange = onValueChange,
+        onValueChange = { newValue ->
+            if (newValue.length <= 7) {
+                onValueChange(newValue)
+            }
+        },
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         visualTransformation = visualTransformation,
@@ -84,11 +90,16 @@ fun NickNameTextField(
                 Column(
                     modifier = Modifier
                         .background(
-                            color = if(isValid) colors.paleLime else colors.veryLightGray,
+                            color = if (isValid) colors.paleLime else colors.veryLightGray,
                             shape = RoundedCornerShape(10.5.dp)
                         )
                         .padding(horizontal = 7.dp, vertical = 4.dp)
-                        .align(Alignment.CenterEnd),
+                        .align(Alignment.CenterEnd)
+                        .clickable(
+                            interactionSource = null,
+                            indication = null,
+                            onClick = onCheckValidNickname
+                        ),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
@@ -113,6 +124,7 @@ private fun BasicPreview() {
         NickNameTextField(
             value = "",
             onValueChange = {},
+            onCheckValidNickname = {},
             isValid = true,
             placeholder = "닉네임",
             keyboardType = KeyboardType.Email,

--- a/app/src/main/java/com/konkuk/moru/presentation/onboarding/model/OnboardingTags.kt
+++ b/app/src/main/java/com/konkuk/moru/presentation/onboarding/model/OnboardingTags.kt
@@ -1,0 +1,31 @@
+package com.konkuk.moru.presentation.onboarding.model
+
+object OnboardingTags {
+    data class TagDef(val id: String, val label: String)
+
+    // 상황 태그(ob_rou_tag1)
+    val SITUATION = listOf(
+        TagDef("6e78b13a-4282-41f4-bb8e-df8ca3baaa85", "#출근길"),
+        TagDef("ded087ad-fc9e-4a70-b016-7f47d7a05e8f", "#지하철"),
+        TagDef("10d0e7c9-8179-4a48-b101-5376eb0f357a", "#퇴근길"),
+        TagDef("672c6fe1-2ba5-4209-9ca0-95274c0d8e82", "#모닝루틴"),
+        TagDef("e0473b71-fe6c-48bb-a1f2-79ccd6efeab8", "#일어나서"),
+        TagDef("13f7788b-4241-43b5-9f52-67ba6a2024c2", "#저녁"),
+        TagDef("7c5cbe2a-ca4c-4134-ae98-836b19f3adc4", "#자기전"),
+        TagDef("4e9282c3-e6a8-445e-89f8-bb0f3fd1a6a2", "#휴일"),
+        TagDef("1516f576-325b-4cba-8871-36a9970fb743", "#공강"),
+    )
+
+    // 활동 태그(ob_rou_tag2)
+    val ACTIVITY = listOf(
+        TagDef("8dcf50a6-ceaa-4e4e-acf8-ef148d50d8fe", "#독서"),
+        TagDef("2ce0449c-ab6e-492a-8d2f-888eed127aa6", "#과제"),
+        TagDef("30da5b0c-adb4-44c3-9be7-8f498fdf5b4b", "#공부"),
+        TagDef("0b2026e7-6b63-4086-b808-763b7238eca7", "#작업"),
+        TagDef("304d8485-60e5-40de-a607-1986888cd0bc", "#다이어트"),
+        TagDef("a2331c30-2aa3-451a-97eb-57f578654447", "#수능"),
+        TagDef("4c1281bf-014f-4aba-829b-be8fb7783a97", "#취준"),
+        TagDef("43605d53-3a05-4c08-93cb-686f6ac55944", "#프로그래밍"),
+        TagDef("8e5874ae-62ec-42a0-a5d8-83e5c252ae48", "#휴식"),
+    )
+}


### PR DESCRIPTION
This pull request introduces the onboarding user profile API integration, allowing the app to communicate with the backend for onboarding-related features such as nickname validation, profile updates, and favorite tag submission. Major changes include new data models, service and repository implementations, dependency injection setup, and updates to the onboarding UI and logic.

### API Integration and Data Models

* Added data classes for onboarding API requests and responses: `FavoriteTagRequest`, `UpdateUserProfileRequest`, `NicknameCheckResponse`, and `UpdateUserProfileResponse` to handle data serialization and deserialization for user onboarding flows.
* Implemented `OBUserService` interface defining endpoints for nickname checking, profile updating, and favorite tag submission.

### Repository and Dependency Injection

* Created `OBUserRepositoryImpl` and its domain interface `OBUserRepository` to encapsulate onboarding-related API logic, including error handling and request logging. 
* Registered the new repository and service in Dagger Hilt modules (`NetworkModule` and `RepositoryModule`), including both authed and authless service variants for different onboarding stages.

### Onboarding ViewModel and UI

* Updated `OnboardingViewModel` to use the new repository for nickname validation, profile submission, and favorite tag submission, including new state flows and sanitization logic for server compatibility.
* Modified `UserInfo` data class and related update functions to align with backend requirements 
* Enhanced `NickNameTextField` UI component to enforce a 7-character limit and trigger nickname validation via a clickable action.

### Miscellaneous

* Added an `enabled` parameter to `MoruButtonTypeA` for better UI state control.
* Minor cleanups and logging improvements in onboarding-related files. [[1]](diffhunk://#diff-4fed4543ed4f20aae9ab7ae4fb7ae5791d3c6fcdc257e2b9dbcd875c986e54b5L21-R21) [[2]](diffhunk://#diff-06d4853e3c931db6f7f1cc0c11096c318d2e56ab62836183c43f9366678c8f5dL86-R156)